### PR TITLE
Clean up README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # VulnCheck Jupyter Notebooks
 
-Jupyter allows you to easily combine markdown and code into a combined canvas view called a notebook. There are several tools that allow you to edit and run code in a Jupyter notebook.project will provides example Jupyter notebook that refresh on a daily basis by pulling data from the VulnCheck and display charts using that data.
+Jupyter allows you to combine markdown and code into a single interactive canvas. This project provides example Jupyter notebooks that pull data from VulnCheck and display it in charts.
+
+For more actively maintained examples, see [vulncheck-oss/vulnerability-research](https://github.com/vulncheck-oss/vulnerability-research).
 
 ## Setup / Documentation
 A walkthrough for setting up your first Jupyter Notebook w/ VulnCheck is available here: https://docs.vulncheck.com/integrations/jupyter
@@ -9,4 +11,6 @@ A walkthrough for setting up your first Jupyter Notebook w/ VulnCheck is availab
 | Jupyter Notebook | Description | VulnCheck Index(s) |
 | --- | --- | --- |
 | [Exploitation Timeline](https://github.com/vulncheck-oss/jupyter-notebooks/blob/main/exploitation-timeline/exploitation-timeline.ipynb) | A look at 2023/2024 Exploitation Timelines | exploits |
-| [VulnCheck KEV Dashboard](https://github.com/vulncheck-oss/jupyter-notebooks/blob/main/vulncheck-kev/vulncheck-kev-dashboard.ipynb) | A comparison between VulnCheck Known Exploited Vulnerabilties & CISA KEV | vulncheck-kev |
+| [VulnCheck KEV Dashboard (2024)](https://github.com/vulncheck-oss/jupyter-notebooks/blob/main/vulncheck-kev/2024-dashboard.ipynb) | A comparison between VulnCheck Known Exploited Vulnerabilties & CISA KEV for 2024 | vulncheck-kev |
+| [VulnCheck KEV Dashboard (2025)](https://github.com/vulncheck-oss/jupyter-notebooks/blob/main/vulncheck-kev/2025-dashboard.ipynb) | A comparison between VulnCheck Known Exploited Vulnerabilties & CISA KEV for 2025 | vulncheck-kev |
+| [VulnCheck SDK for Python](https://github.com/vulncheck-oss/jupyter-notebooks/blob/main/example.ipynb) | An introduction to querying VulnCheck data with the official Python client | botnet |


### PR DESCRIPTION
## Summary
- Fixes grammar in the intro and drops the now-inaccurate "refreshes daily" claim
- Adds a pointer to vulncheck-oss/vulnerability-research as a more actively maintained set of examples
- Fixes the notebook table to match actual files: splits the KEV dashboard row into 2024/2025, adds example.ipynb

Closes #28

## Test plan
- [x] Confirmed via `find . -name "*.ipynb"` that table entries match real files